### PR TITLE
Increase HTTP and socket timeouts

### DIFF
--- a/balenasign/start.sh
+++ b/balenasign/start.sh
@@ -61,4 +61,4 @@ then
   fi
 fi
 
-exec /usr/local/bin/uwsgi --http-socket :8080 --uid balenasign --gid balenasign --processes 4 --chdir /opt/balena/balenasign --pythonpath /opt/balena/balenasign/app --module balenasign.app
+exec /usr/local/bin/uwsgi --http-socket :8080 --socket-timeout 300 --http-timeout 300 --uid balenasign --gid balenasign --processes 4 --chdir /opt/balena/balenasign --pythonpath /opt/balena/balenasign/app --module balenasign.app


### PR DESCRIPTION
This is useful for slow clients or when proxying via the public device URL in balenaCloud. In practice we have observed that the default 60s is exactly the boundary that sometimes works and sometimes times out.