### PR TITLE
Use balena-cloud authentication for HTTP security

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Service used to sign data over the network and retrieve the respective public
 keys. The service is a rough analogy to TPM hardware - it holds private keys
 that it never exposes and provides an API that lets users use them for signing.
 
+## Authorization
+
+Balena sign uses balenaCloud as the authentication backend. Authorization is controlled by specifying a `FLEET_ID` environment variable. This value enforces that the balenaCloud API key provided must have permissions (operator/developer/etc) access to that fleet to be authorized with this application.
+
+API Keys are handled by passing them in the `X-API-KEY` header like in the follow httpie request:
+
+```
+http POST 10.0.0.13/gpg/keys \
+  "Content-Type: application/json" \
+  "X-API-KEY: $AUTH" <-- your balenaCloud api token
+  ...
+```
+
 ## Setup
 
 [![balena deploy button](https://www.balena.io/deploy.svg)](https://dashboard.balena-cloud.com/deploy?repoUrl=https://github.com/balena-os/balena-sign)
@@ -15,10 +28,14 @@ just fine even though x86 HW is likely to generally perform better due to more
 crypto features implemented in hardware.
 
 1. Deploy the app to balenaCloud.
-2. Add at least one API key - this is at this moment done by setting
-   an environment variable named `BALENASIGN_API_KEY_${API_KEY}` with
-   a username as value. Example: `BALENASIGN_API_KEY_123456=jenkins` means
-   API key `123456` will map to user `jenkins`.
+2. Set the `FLEED_ID` environment variable for balena-sign to check for authentication.
+
+## Configuration
+
+You can specify a different API domain for the authentication backend.
+
+By default balena-sign will use `api.balena-cloud.com` but you can override this by setting
+`BALENA_API_DOMAIN` as an environment variable with the domain for the new balenaCloud API.
 
 ### Optional
 

--- a/balenasign/Dockerfile.template
+++ b/balenasign/Dockerfile.template
@@ -22,4 +22,6 @@ COPY api.yml /opt/balena/balenasign/
 RUN chown -R balenasign:balenasign /opt/balena/balenasign
 RUN chmod 0700 /opt/balena/balenasign/secrets/gpg
 
+ENV HOME=/tmp
+
 CMD /usr/local/bin/start.sh

--- a/balenasign/api.yml
+++ b/balenasign/api.yml
@@ -20,7 +20,7 @@ paths:
     get:
       operationId: balenasign.gpg.key
       parameters:
-      - $ref: "#/components/parameters/gpgKey"
+        - $ref: "#/components/parameters/gpgKey"
       responses:
         200:
           description: Armored GPG public key for the given fingerprint
@@ -33,7 +33,7 @@ paths:
     post:
       operationId: balenasign.gpg.new
       security:
-      - apiKey: []
+        - apiKey: []
       requestBody:
         content:
           application/json:
@@ -51,7 +51,7 @@ paths:
     post:
       operationId: balenasign.gpg.sign
       security:
-      - apiKey: []
+        - apiKey: []
       requestBody:
         content:
           application/json:
@@ -69,7 +69,7 @@ paths:
     post:
       operationId: balenasign.cert.new
       security:
-      - apiKey: []
+        - apiKey: []
       requestBody:
         content:
           application/json:
@@ -87,7 +87,7 @@ paths:
     get:
       operationId: balenasign.cert.get
       parameters:
-      - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certId"
       responses:
         200:
           description: The requested certificate in PEM format
@@ -100,7 +100,7 @@ paths:
     get:
       operationId: balenasign.secureboot.pk
       parameters:
-      - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certId"
       responses:
         200:
           description: base64-encoded platform key for UEFI
@@ -113,7 +113,7 @@ paths:
     get:
       operationId: balenasign.secureboot.kek
       parameters:
-      - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certId"
       responses:
         200:
           description: base64-encoded key exchange key for UEFI
@@ -126,7 +126,7 @@ paths:
     get:
       operationId: balenasign.secureboot.db
       parameters:
-      - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certId"
       responses:
         200:
           description: base64-encoded db for UEFI
@@ -139,7 +139,7 @@ paths:
     post:
       operationId: balenasign.secureboot.sign
       security:
-      - apiKey: []
+        - apiKey: []
       requestBody:
         content:
           application/json:
@@ -157,7 +157,7 @@ paths:
     get:
       operationId: balenasign.kmod.cert
       parameters:
-      - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certId"
       responses:
         200:
           description: Certificate to verify kernel modules signature
@@ -170,7 +170,7 @@ paths:
     post:
       operationId: balenasign.kmod.sign
       security:
-      - apiKey: []
+        - apiKey: []
       requestBody:
         content:
           application/json:
@@ -187,7 +187,7 @@ paths:
 components:
   securitySchemes:
     apiKey:
-      x-apikeyInfoFunc: balenasign.apikey.get
+      x-apikeyInfoFunc: balenasign.auth.validate
       type: apiKey
       in: header
       name: X-API-Key
@@ -227,8 +227,8 @@ components:
       type: integer
       default: 2048
       enum:
-      - 2048
-      - 4096
+        - 2048
+        - 4096
 
     gpgKey:
       type: string
@@ -254,7 +254,7 @@ components:
     gpgKeysResponse:
       type: object
       required:
-      - keys
+        - keys
       properties:
         keys:
           $ref: "#/components/schemas/gpgKeyFingerprintList"
@@ -262,8 +262,8 @@ components:
     gpgNewRequest:
       type: object
       required:
-      - name_real
-      - name_email
+        - name_real
+        - name_email
       properties:
         name_real:
           $ref: "#/components/schemas/gpgKeyNameReal"
@@ -277,7 +277,7 @@ components:
     gpgNewResponse:
       type: object
       required:
-      - fingerprint
+        - fingerprint
       properties:
         fingerprint:
           $ref: "#/components/schemas/gpgKeyFingerprint"
@@ -285,7 +285,7 @@ components:
     gpgKeyResponse:
       type: object
       required:
-      - key
+        - key
       properties:
         key:
           $ref: "#/components/schemas/gpgKey"
@@ -293,8 +293,8 @@ components:
     gpgSignRequest:
       type: object
       required:
-      - key_id
-      - payload
+        - key_id
+        - payload
       properties:
         key_id:
           $ref: "#/components/schemas/gpgKeyFingerprint"
@@ -304,7 +304,7 @@ components:
     gpgSignResponse:
       type: object
       required:
-      - signature
+        - signature
       properties:
         signature:
           $ref: "#/components/schemas/base64"
@@ -312,8 +312,8 @@ components:
     certNewRequest:
       type: object
       required:
-      - subject
-      - cert_id
+        - subject
+        - cert_id
       properties:
         cert_id:
           $ref: "#/components/schemas/certId"
@@ -325,7 +325,7 @@ components:
     certNewResponse:
       type: object
       required:
-      - cert
+        - cert
       properties:
         cert:
           $ref: "#/components/schemas/certData"
@@ -333,7 +333,7 @@ components:
     securebootPKResponse:
       type: object
       required:
-      - pk
+        - pk
       properties:
         pk:
           $ref: "#/components/schemas/base64"
@@ -341,7 +341,7 @@ components:
     securebootKEKResponse:
       type: object
       required:
-      - kek
+        - kek
       properties:
         kek:
           $ref: "#/components/schemas/base64"
@@ -349,7 +349,7 @@ components:
     securebootDbResponse:
       type: object
       required:
-      - db
+        - db
       properties:
         db:
           $ref: "#/components/schemas/base64"
@@ -357,8 +357,8 @@ components:
     securebootSignRequest:
       type: object
       required:
-      - key_id
-      - payload
+        - key_id
+        - payload
       properties:
         key_id:
           $ref: "#/components/schemas/certId"
@@ -368,7 +368,7 @@ components:
     securebootSignResponse:
       type: object
       required:
-      - signed
+        - signed
       properties:
         signed:
           $ref: "#/components/schemas/base64"
@@ -376,7 +376,7 @@ components:
     kmodCertResponse:
       type: object
       required:
-      - cert
+        - cert
       properties:
         cert:
           type: string
@@ -384,8 +384,8 @@ components:
     kmodSignRequest:
       type: object
       required:
-      - key_id
-      - payload
+        - key_id
+        - payload
       properties:
         key_id:
           $ref: "#/components/schemas/certId"
@@ -395,7 +395,7 @@ components:
     kmodSignResponse:
       type: object
       required:
-      - signed
+        - signed
       properties:
         signed:
           $ref: "#/components/schemas/base64"

--- a/balenasign/app/balenasign/app.py
+++ b/balenasign/app/balenasign/app.py
@@ -3,20 +3,19 @@ import logging
 
 import balenasign.config
 from balenasign.config import load as load_config
-from balenasign.utils import init_logging
-
 
 LOG = logging.getLogger("app")
 
-
 def create_application():
+    logging.basicConfig(level=logging.INFO)
     load_config(glob=True)
-    init_logging()
 
-    LOG.info("Loaded %d API keys", len(balenasign.config.CONFIG.api_keys))
+    LOG.info(
+        f" api_domain={balenasign.config.CONFIG.api_domain} fleet_id={balenasign.config.CONFIG.fleet_id}")
 
     app = connexion.FlaskApp("balena sign API", options={"swagger_ui": False})
     app.add_api("api.yml")
     return app.app
+
 
 application = create_application()

--- a/balenasign/app/balenasign/auth.py
+++ b/balenasign/app/balenasign/auth.py
@@ -1,0 +1,20 @@
+from balena import Balena 
+from balena.exceptions import ApplicationNotFound
+
+from balenasign.config import CONFIG
+
+def validate(key, fleet_id=CONFIG.fleet_id, required_scopes=None):
+    balena_client = get_client(key, CONFIG.api_domain)
+    try:
+        if 'app_name' not in balena_client.models.application.get_by_id(fleet_id):
+            raise Exception("Unexpected response from fetching application data. Maybe you don't have access ?")
+    except (ApplicationNotFound, Exception):
+        return None
+
+    return {"uid": balena_client.auth.who_am_i()}
+
+def get_client(key, domain):
+    balena_client = Balena()
+    balena_client.settings.set(key="api_domain", value=domain)
+    balena_client.auth.login_with_token(key)
+    return balena_client

--- a/balenasign/app/balenasign/config.py
+++ b/balenasign/app/balenasign/config.py
@@ -1,40 +1,44 @@
+import re
 import os
 
-CONFIG_KEY_PREFIX = "BALENASIGN_"
-API_KEY_PREFIX = "API_KEY_"
-
+DEFAULT_API_DOMAIN = "api.balena-cloud.com"
 
 CONFIG = None
 
 
 class Config(object):
-    def __init__(self, api_keys):
-        if not isinstance(api_keys, dict):
-            raise ValueError("`api_keys` must be a dict api_key ~> user")
-        self._api_keys = api_keys
+    def __init__(self, api_domain, fleet_id):
+        if not is_domain(api_domain):
+            raise ValueError(
+                f"`api_domain` value: '{api_domain}' is not a valid domain")
+        if not fleet_id.isdigit():
+            raise ValueError(
+                f"`fleet_id` value: '{fleet_id}' is not a valid fleet ID.")
+        self._api_domain = api_domain
+        self._fleet_id = fleet_id
 
     @property
-    def api_keys(self):
-        return self._api_keys
+    def api_domain(self):
+        return self._api_domain
+
+    @property
+    def fleet_id(self):
+        return self._fleet_id
+
+
+def is_domain(value):
+    domain_regex = r'^[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}$'
+    return bool(re.match(domain_regex, value))
 
 
 def load(glob=False):
-    api_keys = {}
+    api_domain = os.environ.get("BALENA_API_DOMAIN", DEFAULT_API_DOMAIN)
+    fleet_id = os.environ.get("FLEET_ID")
 
-    for key, value in os.environ.items():
-        if not key.startswith(CONFIG_KEY_PREFIX):
-            continue
+    if not fleet_id:
+        raise ValueError("`FLEET_ID` env var cannot be empty!")
 
-        key_noprefix = key[len(CONFIG_KEY_PREFIX):]
-
-        if key_noprefix.startswith(API_KEY_PREFIX):
-            api_key = key_noprefix[len(API_KEY_PREFIX):]
-            api_keys[api_key] = value
-            continue
-
-        # Handle other config options eventually
-
-    result = Config(api_keys=api_keys)
+    result = Config(api_domain, fleet_id)
 
     if glob:
         global CONFIG

--- a/balenasign/app/balenasign/utils.py
+++ b/balenasign/app/balenasign/utils.py
@@ -42,7 +42,3 @@ def get_esl_path(cert_path, uuid=DEFAULT_EFI_UUID):
             raise RuntimeError("Failed to generate EFI signature list")
 
     return esl_path
-
-
-def init_logging(level=logging.INFO):
-    logging.basicConfig(level=level)

--- a/balenasign/requirements.txt
+++ b/balenasign/requirements.txt
@@ -1,5 +1,5 @@
 Werkzeug==1.0.1
-attrs==20.3.0
+attrs==22.2.0
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
@@ -21,3 +21,4 @@ six==1.15.0
 urllib3==1.26.3
 uWSGI==2.0.19.1
 Werkzeug==1.0.1
+balena-sdk==12.3.1


### PR DESCRIPTION
Checks if the api key provided in `X-API-KEY` has permissions to query the fleet id specified in the environment variable `FLEET_ID`. I also added this security requirement for ALL endpoints instead of the ones that just modified data.

This allows for user management to be control from balenaCloud. Simply invite people to your fleet and balena-sign will now authorize requests to those people.

Also supports configuring the authentication backend to point to another domain. By default is uses `api.balena-cloud.com` but this can be swapped to `api.balena-staging.com` etc. This is controlled via `BALENA_API_DOMAIN` env var.