### PR TITLE
Default to SHA256 hashes in X.509 certificates

### DIFF
--- a/balenasign/app/balenasign/cert.py
+++ b/balenasign/app/balenasign/cert.py
@@ -40,7 +40,7 @@ def new(body, user):
     cmd = [
         "openssl", "req", "-new", "-x509", "-newkey", "rsa:%d" % key_length,
         "-subj", body["subject"], "-keyout", key_path, "-out", cert_path,
-        "-days", "3650", "-sha512", "-nodes"
+        "-days", "3650", "-sha256", "-nodes"
     ]
 
     cmd_result = subprocess.run(cmd)


### PR DESCRIPTION
This is the minimum required by the UEFI spec, anything more causes failures in some UEFI implementations.

While this is technically a regression (going down from SHA512 to SHA256), we expect a separate PR to expose this in the API and make SHA512 available if requested.