### PR TITLE
Added a volume for secret storage to persist across updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,12 @@ x-network-privileges-trait: &with-network-privileges
     - SYS_RESOURCE
 
 x-base-service-definition: &base-service
+  volumes:
+    - secrets:/opt/balena/balenasign/secrets
   restart: unless-stopped
+
+volumes:
+  secrets:
 
 services:
   # https://github.com/balena-io/open-balena-haproxy


### PR DESCRIPTION
This ensures that whenever the application is updated on a balenaOS device, the secrets added are not removed since they currently live on the container layer.