### PR TITLE
Allow signing multiple certificates for secure boot variables

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -153,7 +153,7 @@ paths:
     get:
       operationId: secureboot.get_pk
       parameters:
-        - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certIdList"
       responses:
         200:
           description: base64-encoded platform key for UEFI
@@ -184,7 +184,7 @@ paths:
     get:
       operationId: secureboot.get_kek
       parameters:
-        - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certIdList"
       responses:
         200:
           description: base64-encoded key exchange key for UEFI
@@ -215,7 +215,7 @@ paths:
     get:
       operationId: secureboot.get_db
       parameters:
-        - $ref: "#/components/parameters/certId"
+        - $ref: "#/components/parameters/certIdList"
       responses:
         200:
           description: base64-encoded db for UEFI
@@ -338,6 +338,15 @@ components:
       schema:
         $ref: "#/components/schemas/certId"
 
+    certIdList:
+      name: cert_id
+      description: Multiple IDs of the certificates to fetch
+      in: path
+      required: true
+      explode: true
+      schema:
+        $ref: "#/components/schemas/certIdList"
+
   schemas:
     base64:
       type: string
@@ -353,6 +362,11 @@ components:
     certData:
       type: string
       example: "-----BEGIN CERTIFICATE-----\nMIIDxzCCAq+gAwIBAgIUSuCy+XvUSQSSDinU0qUAmt4lnZ0wDQYJKoZIhvcNAQEL\nBQAwczELMAkGA1UEBhMCVVMxEzARBgNVBAgMCldhc2hpbmd0b24xEDAOBgNVBAcM\nB1NlYXR0bGUxFTATBgNVBAoMDEJhbGVuYSwgSW5jLjELMAkGA1UECwwCSVQxGTAX\nBgNVBAMMEGJhbGVuYS1jbG91ZC5jb20wHhcNMjMwMjA4MjMyOTM0WhcNMzMwMjA1\nMjMyOTM0WjBzMQswCQYDVQQGEwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjEQMA4G\nA1UEBwwHU2VhdHRsZTEVMBMGA1UECgwMQmFsZW5hLCBJbmMuMQswCQYDVQQLDAJJ\nVDEZMBcGA1UEAwwQYmFsZW5hLWNsb3VkLmNvbTCCASIwDQYJKoZIhvcNAQEBBQAD\nggEPADCCAQoCggEBAMBUb+7YMkQqJiTZPAVd62ifTWP3+AjjYIfNoroTZFnLVPQ3\n54dv1sAoPek7xesBwwCuq9HoKBHp7Uk9bNiE13JsMp5DucnndHIuiQGd+XYkHTAQ\nhhrUrzaBX+R7fzaL2ziHz7sRgUn1HK17Vasc9zOmiF7grrG89QYkBa53Se9q2/rA\nqOqi12FdnhcBUwha+/58CpCXi/m8fKj6U9z46GJkx++Lx65I7nWvdJFTT9oKZAQT\nzV9igB3SU2QHREE5bQoLr2h8Lc8l3znyyy9MV0xrUsccct8VSMd0jiETJfpA/Bjp\n/oTajcJKjebQeskFCKdxoAb2hQosBUhvBIswUxkCAwEAAaNTMFEwHQYDVR0OBBYE\nFBck/AQEhIe4i0l1H5dN6KsaI9HrMB8GA1UdIwQYMBaAFBck/AQEhIe4i0l1H5dN\n6KsaI9HrMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJWEw5df\nngqgMyp0mvyRV+BodQweAUIQ/DpCTY+EHET1DncNKVSB3M4JolGbbD7qnQpN1+PE\ng7J+ukxtfc2QmsEs9Wi+/+01j9iCm0m+H5JoOxBKJ+kBYJEciHjcosTCRCqc++Dm\nXhBG2DjASP/oOOLc9NzUPMXiSNXfBNkheluJNbNGMV6qDnEVnTG/5/hnbvylGONi\nb2UxbEo0J8l+1iXkWMLkH6U5NDit/97WvJlaE/oJJVCp+DNbupH/E8b19jW+ht7/\nEKt5BlUoE+d4UQJfai8nROkqqw64cxv+f6VgYYZHIqTbKn75SYBEy85mHsdv3TYN\nCRhjJiTOvxQg9FE=\n-----END CERTIFICATE-----\n"
+
+    certIdList:
+      type: array
+      items:
+        $ref: "#/components/schemas/certId"
 
     keyLength:
       type: integer
@@ -578,7 +592,9 @@ components:
         append:
           type: boolean
         key_id:
-          $ref: "#/components/schemas/certId"
+          oneOf:
+            - $ref: "#/components/schemas/certId"
+            - $ref: "#/components/schemas/certIdList"
         signing_key_id:
           $ref: "#/components/schemas/certId"
 

--- a/src/secureboot.py
+++ b/src/secureboot.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import tempfile
 
-from utils import X509_DIR
+from utils import X509_DIR, get_certlist_name
 from utils import get_der_path, get_esl_path, unlink_if_exists
 
 
@@ -14,20 +14,24 @@ LOG = logging.getLogger("secureboot")
 ALLOWED_VARS = {"PK", "KEK", "db", "dbx"}
 
 
-def _get_signed_esl(cert_id, var):
+def _get_signed_esl(cert_ids, var):
+    if isinstance(cert_ids, str):
+        cert_ids = [cert_ids]
+
+    if not isinstance(cert_ids, list):
+        raise ValueError(
+            "`cert_id` must either be a single ID or a list of IDs"
+        )
+
     if var not in ALLOWED_VARS:
         raise ValueError("`var` must be one of %s" % ALLOWED_VARS)
 
-    cert_filename = "%s.crt" % cert_id
-    cert_path = os.path.join(X509_DIR, cert_filename)
-
-    if not os.path.isfile(cert_path):
-        return {"error": "Certificate '%s' does not exist" % cert_id}, 404
-
-    auth_path = "%s.%s.auth" % (cert_path[:-4], var)
+    certlist_name = get_certlist_name(cert_ids)
+    auth_filename = "%s.%s.auth" % (certlist_name, var)
+    auth_path = os.path.join(X509_DIR, auth_filename)
     if not os.path.isfile(auth_path):
         return {
-            "error": "%s not found for certificate '%s'" % (var, cert_id)
+            "error": "%s not found for given certificate list" % var
         }, 404
 
     with open(auth_path, "rb") as f:
@@ -37,24 +41,30 @@ def _get_signed_esl(cert_id, var):
         var.lower(): binascii.b2a_base64(auth_data).decode().rstrip("\n")
     }
 
-    esl_path = get_esl_path(cert_path)
+    # This does not call get_esl_path as that has potential side-effects
+    esl_path = os.path.join(X509_DIR, "%s.esl" % certlist_name)
     if os.path.isfile(esl_path):
         with open(esl_path, "rb") as f:
             esl_data = f.read()
 
         response["esl"] = binascii.b2a_base64(esl_data).decode().rstrip("\n")
 
-    der_path = get_der_path(cert_path)
-    if os.path.isfile(der_path):
-        with open(der_path, "rb") as f:
-            der_data = f.read()
+    response["der"] = []
+    for cert_id in sorted(set(cert_ids)):
+        cert_path = os.path.join(X509_DIR, "%s.crt" % cert_id)
+        der_path = get_der_path(cert_path)
+        if os.path.isfile(der_path):
+            with open(der_path, "rb") as f:
+                der_data = f.read()
 
-        response["der"] = binascii.b2a_base64(der_data).decode().rstrip("\n")
+            response["der"].append(
+                binascii.b2a_base64(der_data).decode().rstrip("\n")
+            )
 
     return response
 
 
-def _sign_esl(signing_cert_id, var, cert_id=None, esl_data=None, append=False):
+def _sign_esl(signing_cert_id, var, cert_ids=None, esl_data=None, append=False):
     if var not in ALLOWED_VARS:
         raise ValueError("`var` must be one of %s" % ALLOWED_VARS)
 
@@ -72,19 +82,39 @@ def _sign_esl(signing_cert_id, var, cert_id=None, esl_data=None, append=False):
             "error": "Private key '%s' does not exist" % signing_cert_id
         }, 404
 
-    if cert_id is not None:
-        cert_filename = "%s.crt" % cert_id
-        cert_path = os.path.join(X509_DIR, cert_filename)
-        if not os.path.isfile(cert_path):
-            return {"error": "Certificate '%s' does not exist" % cert_id}, 404
+    if cert_ids is not None:
+        # This only operates on lists even if the list length is 1
+        if isinstance(cert_ids, str):
+            cert_ids = [cert_ids]
 
-        auth_path = "%s.%s.auth" % (cert_path[:-4], var)
+        if not isinstance(cert_ids, list):
+            raise ValueError(
+                "`cert_id` must either be a single ID or a list of IDs"
+            )
+
+        # Check whether the individual certificates exist
+        cert_errors = []
+        cert_paths = []
+        for cert_id in cert_ids:
+            cert_filename = "%s.crt" % cert_id
+            cert_path = os.path.join(X509_DIR, cert_filename)
+
+            if not os.path.isfile(cert_path):
+                cert_errors.append("Certificate '%s' does not exist" % cert_id)
+                continue
+
+            cert_paths.append(cert_path)
+
+        # Bail out on error - a single missing cert means the list is invalid
+        if cert_errors:
+            return {"error": "; ".join(cert_errors)}, 404
+
+        esl_path = get_esl_path(cert_paths)
+        auth_path = "%s.%s.auth" % (esl_path[:-4], var)
         if os.path.isfile(auth_path):
             return {
                 "error": "%s for '%s' has already been signed" % (var, cert_id)
             }, 409
-
-        esl_path = get_esl_path(cert_path)
 
     elif esl_data is not None:
         with tempfile.NamedTemporaryFile(delete=False) as esl_file:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,8 @@
 import errno
+import hashlib
 import logging
 import os
+import shutil
 import subprocess
 import uuid
 
@@ -30,21 +32,74 @@ def unlink_if_exists(path):
             raise
 
 
-def get_esl_path(cert_path, efi_uuid=None):
-    if not cert_path.endswith(".crt"):
-        raise ValueError("`cert_path` must end with .crt")
+def get_certlist_name(cert_ids):
+    # In order to uniquely and reproducibly identify a certificate list, this
+    # 1. Removes duplicit cert_ids.
+    # 2. Sorts the cert_ids.
+    # 3. Joins the list of cert_ids together using the NULL byte as the glue.
+    #    Since the NULL byte can not be a part of a cert_id (or in general
+    #    a file name), this ensures cert_ids won't be able to cause conflicts.
+    # 4. Hashes the result for a constant output length, there are no crypto
+    #    requirements on the hash.
+    hasher = hashlib.sha3_256()
+    hasher.update(b"\x00".join(cid.encode() for cid in sorted(set(cert_ids))))
+    return hasher.hexdigest()
 
-    if efi_uuid is None:
-        efi_uuid = uuid.uuid4()
 
-    esl_path = "%s.esl" % (cert_path[:-4])
+def get_esl_path(cert_paths, efi_uuid=None):
+    # This only operates on lists, even if the list length is 1
+    if isinstance(cert_paths, str):
+        cert_paths = [cert_paths]
 
-    if not os.path.isfile(esl_path):
-        cmd = ["cert-to-efi-sig-list", "-g", str(efi_uuid), cert_path, esl_path]
+    if not isinstance(cert_paths, list):
+        raise ValueError("`cert_paths` must be a list")
+
+    # First turn the individual certs into esl
+    cert_ids = set()
+    cert_esl_paths = []
+    esl_errors = []
+    for cert_path in cert_paths:
+        if not cert_path.endswith(".crt"):
+            raise ValueError("`cert_path` must end with .crt")
+
+        cert_id = os.path.basename(cert_path)[:-4]
+        cert_ids.add(cert_id)
+
+        if efi_uuid is None:
+            efi_uuid = uuid.uuid4()
+
+        cert_esl_path = "%s.esl" % (cert_path[:-4])
+
+        if os.path.isfile(cert_esl_path):
+            continue
+
+        cmd = ["cert-to-efi-sig-list", "-g", str(efi_uuid), cert_path, cert_esl_path]
         cmd_result = subprocess.run(cmd)
 
         if cmd_result.returncode != 0:
-            raise RuntimeError("Failed to generate EFI signature list")
+            esl_errors.append(
+                "Failed to generate EFI signature list for %s" % cert_id
+            )
+            continue
+
+        cert_esl_paths.append(cert_esl_path)
+
+    # Bail out if at least one esl failed to generate
+    if esl_errors:
+        raise RuntimeError("; ".join(esl_errors))
+
+    certlist_name = get_certlist_name(cert_ids)
+    esl_path = os.path.join(X509_DIR, "%s.esl" % certlist_name)
+
+    # If the esl file exists, perform no additional checks
+    if os.path.isfile(esl_path):
+        return esl_path
+
+    # Concatenate the individual esls into the single resulting esl
+    with open(esl_path, "wb") as esl_file:
+        for cert_esl_path in cert_esl_paths:
+            with open(cert_esl_path, "rb") as cert_esl_file:
+                shutil.copyfileobj(cert_esl_file, esl_file)
 
     return esl_path
 


### PR DESCRIPTION
In order to be able to properly rotate keys, we need to be able to distribute updates that contain multiple certificates valid during overlapping periods. This PR makes it possible to specify a list of certificates when signing PK, KEK and db.