### PR TITLE
Allow signing external ESL at db level

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -171,7 +171,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/securebootESLSignRequest"
+              $ref: "#/components/schemas/securebootInternalESLSignRequest"
       responses:
         200:
           description: empty
@@ -202,7 +202,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/securebootESLSignRequest"
+              $ref: "#/components/schemas/securebootInternalESLSignRequest"
       responses:
         200:
           description: empty
@@ -233,7 +233,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/securebootESLSignRequest"
+              oneOf:
+                - $ref: "#/components/schemas/securebootInternalESLSignRequest"
+                - $ref: "#/components/schemas/securebootExternalESLSignRequest"
       responses:
         200:
           description: empty
@@ -548,13 +550,24 @@ components:
         db:
           $ref: "#/components/schemas/base64"
 
-    securebootESLSignRequest:
+    securebootInternalESLSignRequest:
       type: object
       required:
         - key_id
       properties:
         key_id:
           $ref: "#/components/schemas/certId"
+        signing_key_id:
+          $ref: "#/components/schemas/certId"
+
+    securebootExternalESLSignRequest:
+      type: object
+      required:
+        - esl
+        - signing_key_id
+      properties:
+        esl:
+          $ref: "#/components/schemas/base64"
         signing_key_id:
           $ref: "#/components/schemas/certId"
 


### PR DESCRIPTION
We are moving to authenticating the bootable images by hashes of the EFI binaries instead of an embedded signature. This way the ESL with the hashes is built by the client (yocto) and sent to sign as is. This patch extends the secureboot/db signing API to allow sending an external ESL instead of cert_id.

This only applies to db, PK and KEK are still certificates.