### PR TITLE
Allow signing db for appending

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -555,6 +555,8 @@ components:
       required:
         - key_id
       properties:
+        append:
+          type: boolean
         key_id:
           $ref: "#/components/schemas/certId"
         signing_key_id:
@@ -566,6 +568,8 @@ components:
         - esl
         - signing_key_id
       properties:
+        append:
+          type: boolean
         esl:
           $ref: "#/components/schemas/base64"
         signing_key_id:


### PR DESCRIPTION
EFI variables can be either flagged as appends or replacements. A replacement is always time-authenticated, which in our use-case breaks rollbacks. Appending bypasses the time protection and gives us better control in HUP scripts.