### PR TITLE
Allow signing for dbx

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -244,6 +244,26 @@ paths:
               schema:
                 $ref: "#/components/schemas/securebootESLSignResponse"
 
+  /secureboot/dbx:
+    post:
+      operationId: secureboot.sign_dbx
+      security:
+        - apiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/securebootInternalESLSignRequest"
+                - $ref: "#/components/schemas/securebootExternalESLSignRequest"
+      responses:
+        200:
+          description: empty
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/securebootESLSignResponse"
+
   /secureboot/efi:
     post:
       operationId: secureboot.sign_efi


### PR DESCRIPTION
With db appends we also need dbx to be able to prevent older systems from booting. This patch adds the API necessary to sign for dbx EFI variable.