### PR TITLE
add the option to change to a custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ crypto features implemented in hardware.
 
 1. Deploy the app to balenaCloud.
 2. Set the `FLEED_ID` environment variable for balena-sign to check for authentication.
+3. If you are using openBalena set `BALENA_DOMAIN` to your respective api (sub)domain.
 
 You can bootstrap all the secrets necessary for integration with balenaOS yocto build using a single bootstrap command:
 ```
 curl -X POST -H "X-API-Key: XXX" -H "Content-type: application/json" -d '{
   "gpg": {"name_real": "balenaOS GRUB GPG key", "name_email": "security@balena.io"},
+  "rsa": {},
   "certificates": {
     "pk": {"cert_id": "balenaos-pk", "subject": "/CN=balenaOS PK/"},
     "kek": {"cert_id": "balenaos-kek", "subject": "/CN=balenaOS KEK/"},

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ curl -X POST -H "X-API-Key: XXX" -H "Content-type: application/json" -d '{
     "db": {"cert_id": "balenaos-db", "subject": "/CN=balenaOS db/"},
     "kmod": {"cert_id": "balenaos-kmod", "subject": "/CN=key for signing 3rd party balenaOS kernel modules/", "key_length": 4096}
   }
-}'
+}' https://sign.<your-balena-domain>/bootstrap
 ```
 
 `db` is optional, if you are using hashes for authentication, you do not need the `db` certificate and you can omit it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ six==1.15.0
 urllib3==1.26.14
 uWSGI==2.0.21
 Werkzeug==1.0.1
-balena-sdk==12.3.1
+balena-sdk==15.0.0

--- a/src/app.py
+++ b/src/app.py
@@ -58,7 +58,7 @@ def create_application():
     logging.basicConfig(level=logging.INFO)
     load_config(glob=True)
 
-    LOG.info(f"Configured to authenticate with FLEET_ID={config.CONFIG.fleet_id}")
+    LOG.info(f"Configured to authenticate with FLEET_ID={config.CONFIG.fleet_id} at BALENA_DOMAIN={config.CONFIG.balena_domain}")
 
     app = connexion.FlaskApp("balena sign API", options={"swagger_ui": False})
     app.add_api("api.yml")

--- a/src/auth.py
+++ b/src/auth.py
@@ -6,14 +6,14 @@ from config import CONFIG
 def validate(key, fleet_id=CONFIG.fleet_id, required_scopes=None):
     balena_client = get_client(key)
     try:
-        if 'app_name' not in balena_client.models.application.get_by_id(fleet_id):
+        if 'app_name' not in balena_client.models.application.get(fleet_id):
             raise Exception("Unexpected response from fetching application data. Maybe you don't have access ?")
     except (ApplicationNotFound, Exception):
         return None
 
-    return {"uid": balena_client.auth.who_am_i()}
+    return {"uid": balena_client.auth.whoami()["id"]}
 
 def get_client(key):
-    balena_client = Balena()
+    balena_client = Balena({"balena_host": CONFIG.balena_domain})
     balena_client.auth.login_with_token(key)
     return balena_client

--- a/src/config.py
+++ b/src/config.py
@@ -1,25 +1,28 @@
 import re
 import os
 
-DEFAULT_API_DOMAIN = "api.balena-cloud.com"
+DEFAULT_DOMAIN = "balena-cloud.com"
 
 CONFIG = None
 
 
 class Config(object):
-    def __init__(self, api_domain, fleet_id):
-        if not is_domain(api_domain):
+    def __init__(self, balena_domain, fleet_id):
+        if not is_domain(balena_domain):
             raise ValueError(
-                f"`api_domain` value: '{api_domain}' is not a valid domain")
+                f"`balena_domain` value: '{balena_domain}' is not a valid domain")
         if not fleet_id.isdigit():
             raise ValueError(
                 f"`fleet_id` value: '{fleet_id}' is not a valid fleet ID.")
-        self._api_domain = api_domain
-        self._fleet_id = fleet_id
+        self._balena_domain = balena_domain
+
+        # note: the balena sdk uses the fleet id type to distinguish between using a lookup by
+        #       slug name (in case of string) or id (in case of int), so we need to cast it to int
+        self._fleet_id = int(fleet_id)
 
     @property
-    def api_domain(self):
-        return self._api_domain
+    def balena_domain(self):
+        return self._balena_domain
 
     @property
     def fleet_id(self):
@@ -32,13 +35,13 @@ def is_domain(value):
 
 
 def load(glob=False):
-    api_domain = os.environ.get("BALENA_API_DOMAIN", DEFAULT_API_DOMAIN)
+    balena_domain = os.environ.get("BALENA_DOMAIN", DEFAULT_DOMAIN)
     fleet_id = os.environ.get("FLEET_ID")
 
     if not fleet_id:
         raise ValueError("`FLEET_ID` env var cannot be empty!")
 
-    result = Config(api_domain, fleet_id)
+    result = Config(balena_domain, fleet_id)
 
     if glob:
         global CONFIG


### PR DESCRIPTION
This change allows users to configure custom domains for balena, effectively allowing them to use this service with openbalena as well. The config variable has existed, but was actually unused.

Changes overview:
* due to changes in the sdk i refactored the config from specifying just the api-domain to the balena host. _renaming the configuration parameter should not have any negative effects, because the variable was unused anyways_
* updated the documentation to include the new config
* updated the documentation's quick start to work again