### PR TITLE
Add a metrics agent for collecting worker resource metrics.

### DIFF
--- a/cert-manager/certs.json
+++ b/cert-manager/certs.json
@@ -21,5 +21,28 @@
       "CN": "logs-to-vector.${DNS_TLD}"
     },
     "profile": "client"
+  },
+  {
+    "request": {
+      "key": {
+        "algo": "${key_algo}",
+        "size": ${key_size}
+      },
+      "hosts": [
+        "metrics-agent.${DNS_TLD}",
+        "metrics-agent.${TLD}"
+      ],
+      "names": [
+        {
+          "C": "${country}",
+          "L": "${locality_name}",
+          "O": "${org}",
+          "OU": "${org_unit}",
+          "ST": "${state}"
+        }
+      ],
+      "CN": "metrics-agent.${DNS_TLD}"
+    },
+    "profile": "client"
   }
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,3 +185,17 @@ services:
     labels:
       io.balena.features.balena-api: 1
       io.balena.features.supervisor-api: 1
+
+  # https://github.com/balena-io/metrics-agent
+  metrics-agent:
+    image: ghcr.io/balena-io/metrics-agent:v1.0.0
+    volumes:
+      - certs:/certs:ro
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:9273/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    labels:
+      io.resin.features.balena-socket: '1'
+    privileged: true


### PR DESCRIPTION
Related project: https://balena.fibery.io/Work/Project/Add-node-exporter-metrics-to-builder-worker-fleets-600

Change-type: minor