### PR TITLE
patch: Use the default env. var. set by Supervisor

### DIFF
--- a/cert-manager/Dockerfile
+++ b/cert-manager/Dockerfile
@@ -1,4 +1,3 @@
-# FIXME: switch to bh.cr/balena/cert-manager/x.y.z when multi-arch ships
 FROM balena/cert-manager:v0.2.2
 
 COPY *.json /opt/

--- a/src/config.py
+++ b/src/config.py
@@ -33,7 +33,7 @@ def is_domain(value):
 
 def load(glob=False):
     api_domain = os.environ.get("BALENA_API_DOMAIN", DEFAULT_API_DOMAIN)
-    fleet_id = os.environ.get("FLEET_ID")
+    fleet_id = os.environ.get("BALENA_APP_ID", os.environ.get("FLEET_ID")) 
 
     if not fleet_id:
         raise ValueError("`FLEET_ID` env var cannot be empty!")


### PR DESCRIPTION
.. then we can remove the superfluous `FLEET_ID` env. var. currently set on its fleet