### PR TITLE
patch: explicitly allow docker image updates by renovate.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,10 @@
 {
-  "extends": ["github>balena-io/renovate-config"]
+  "extends": ["github>balena-io/renovate-config"],
+  "packageRules": [
+    {
+      "automerge": false,
+      "enabled": true,
+      "matchManagers": ["docker"]
+    }
+  ]
 }


### PR DESCRIPTION
This overrides the package rule in balena-os/renovate-config that disables package updates.

https://github.com/balena-os/renovate-config/blob/eb34653365230f0bda0874c37c37858bfb49e7e3/default.json#L25-L32

Change-type: patch