### PR TITLE
Update openapi-spec-validator and dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,14 +28,14 @@ inflection==0.5.1
 itsdangerous==2.2.0
 jinja2>=3.1.5
 jsonschema==4.26.0
-jsonschema-path==0.3.4
+jsonschema-path==0.5.0
 jsonschema-specifications==2025.9.1
 lazy-object-proxy==1.12.0
 MarkupSafe==3.0.3
-openapi-schema-validator==0.6.3
-openapi-spec-validator==0.7.2
+openapi-schema-validator==0.9.0
+openapi-spec-validator==0.9.0
 packaging==26.2
-pathable==0.4.4
+pathable==0.6.0
 pine-client==0.2.0
 pyasn1==0.6.4
 pyasn1_modules==0.4.2
@@ -48,7 +48,7 @@ python-gnupg==0.5.6
 python-multipart>=0.0.18
 PyYAML==6.0.3
 ratelimit==2.2.1
-referencing==0.35.1
+referencing==0.37.0
 requests==2.34.2
 rfc3339-validator==0.1.4
 rpds-py==0.30.0


### PR DESCRIPTION
`jsonschema-path`, `openapi-schema-validator`, `openapi-spec-validator`, `pathable` and `referencing` need to be bumped together, renovate can't update them one by one.

This replaces:
* https://github.com/balena-os/balena-sign/pull/130
* https://github.com/balena-os/balena-sign/pull/143
* https://github.com/balena-os/balena-sign/pull/144
* https://github.com/balena-os/balena-sign/pull/146
* https://github.com/balena-os/balena-sign/pull/148